### PR TITLE
Issue 3

### DIFF
--- a/ActiveLight.h
+++ b/ActiveLight.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+
+@interface ActiveLight : NSView
+
+@property (nonatomic, assign) BOOL isVisible;  // Property to track circle visibility
+
+- (BOOL)getVisibility;  // Method to toggle the visibility of the circle
+
+- (void)setVisibility:(BOOL)isVisible;  // Method to toggle the visibility of the circle
+
+@end

--- a/ActiveLight.m
+++ b/ActiveLight.m
@@ -2,47 +2,53 @@
 
 @implementation ActiveLight
 
-- (instancetype)initWithFrame:(NSRect)frameRect {
+- (instancetype) initWithFrame:(NSRect)frameRect
+{
     self = [super initWithFrame:frameRect];
-    if (self) {
-        _isVisible = YES;  // Initially, the circle is invisible
-    }
+    if (self)
+      {
+          _isVisible = YES;  // Initially, the circle is invisible
+      }
     return self;
 }
 
 // Override drawRect: to draw the circle
-- (void)drawRect:(NSRect)dirtyRect {
+- (void) drawRect:(NSRect)dirtyRect
+{
     [super drawRect:dirtyRect];
     
-    if (self.isVisible) {
-        // Set the fill color to grey
-        [[NSColor grayColor] setFill];
-        
-        // Define the circle's diameter and radius
-        CGFloat circleDiameter = 4.0;
-        CGFloat circleRadius = circleDiameter / 2.0;
-        
-        // Calculate the center point to draw the circle in the middle of the view
-        NSRect bounds = [self bounds];
-        NSPoint center = NSMakePoint(NSMidX(bounds), NSMidY(bounds));
-        
-        // Define the rectangle for the circle
-        NSRect circleRect = NSMakeRect(center.x - circleRadius, center.y - circleRadius, circleDiameter, circleDiameter);
-        
-        // Create a bezier path for the circle
-        NSBezierPath *circlePath = [NSBezierPath bezierPathWithOvalInRect:circleRect];
-        
-        // Fill the circle
-        [circlePath fill];
-    }
+    if (self.isVisible)
+      {
+          // Set the fill color to grey
+          [[NSColor grayColor] setFill];
+          
+          // Define the circle's diameter and radius
+          CGFloat circleDiameter = 4.0;
+          CGFloat circleRadius = circleDiameter / 2.0;
+          
+          // Calculate the center point to draw the circle in the middle of the view
+          NSRect bounds = [self bounds];
+          NSPoint center = NSMakePoint(NSMidX(bounds), NSMidY(bounds));
+          
+          // Define the rectangle for the circle
+          NSRect circleRect = NSMakeRect(center.x - circleRadius, center.y - circleRadius, circleDiameter, circleDiameter);
+          
+          // Create a bezier path for the circle
+          NSBezierPath *circlePath = [NSBezierPath bezierPathWithOvalInRect:circleRect];
+          
+          // Fill the circle
+          [circlePath fill];
+      }
 }
 
-- (BOOL)getVisibility {
+- (BOOL) getVisibility
+{
     return _isVisible;
 }
 
 // Method to toggle the visibility of the circle
-- (void)setVisibility:(BOOL)isVisible {
+- (void) setVisibility:(BOOL)isVisible
+{
     _isVisible = isVisible;  // Toggle the visibility state
     [self setNeedsDisplay:YES];  // Mark the view as needing display, which calls drawRect:
 }

--- a/ActiveLight.m
+++ b/ActiveLight.m
@@ -1,0 +1,51 @@
+#import "ActiveLight.h"
+
+@implementation ActiveLight
+
+- (instancetype)initWithFrame:(NSRect)frameRect {
+    self = [super initWithFrame:frameRect];
+    if (self) {
+        _isVisible = YES;  // Initially, the circle is invisible
+    }
+    return self;
+}
+
+// Override drawRect: to draw the circle
+- (void)drawRect:(NSRect)dirtyRect {
+    [super drawRect:dirtyRect];
+    
+    if (self.isVisible) {
+        // Set the fill color to grey
+        [[NSColor grayColor] setFill];
+        
+        // Define the circle's diameter and radius
+        CGFloat circleDiameter = 4.0;
+        CGFloat circleRadius = circleDiameter / 2.0;
+        
+        // Calculate the center point to draw the circle in the middle of the view
+        NSRect bounds = [self bounds];
+        NSPoint center = NSMakePoint(NSMidX(bounds), NSMidY(bounds));
+        
+        // Define the rectangle for the circle
+        NSRect circleRect = NSMakeRect(center.x - circleRadius, center.y - circleRadius, circleDiameter, circleDiameter);
+        
+        // Create a bezier path for the circle
+        NSBezierPath *circlePath = [NSBezierPath bezierPathWithOvalInRect:circleRect];
+        
+        // Fill the circle
+        [circlePath fill];
+    }
+}
+
+- (BOOL)getVisibility {
+    return _isVisible;
+}
+
+// Method to toggle the visibility of the circle
+- (void)setVisibility:(BOOL)isVisible {
+    _isVisible = isVisible;  // Toggle the visibility state
+    [self setNeedsDisplay:YES];  // Mark the view as needing display, which calls drawRect:
+}
+
+@end
+

--- a/DockAppController.h
+++ b/DockAppController.h
@@ -14,8 +14,8 @@
 
 - (void)setupDockWindow;
 - (void)addApplicationIcon:(NSString *)appName withDockedStatus:(BOOL)isDocked;
-- (DockIcon *)generateIcon:(NSString *)appName;
-- (NSRect)generateLocation:(NSString *)dockPosition;
+- (DockIcon *)generateIcon:(NSString *)appName withDockedStatus:(BOOL)isDocked;
+- (NSRect)generateLocation:(NSString *)dockPosition forDockedStatus:(BOOL)isDocked;
 - (void)addDivider;
 - (void)iconClicked:(id)sender;
 - (void)dockIcon:(NSString *)appName;

--- a/DockAppController.h
+++ b/DockAppController.h
@@ -5,8 +5,8 @@
 @interface DockAppController : NSObject <NSApplicationDelegate>
 
 @property (strong) NSWindow *dockWindow;
-@property (strong) NSMutableArray *dockedIcons;
-@property (strong) NSMutableArray *undockedIcons;
+@property (strong) NSMutableDictionary *dockedIcons;
+@property (strong) NSMutableDictionary *undockedIcons;
 @property (strong) NSWorkspace *workspace;
 @property CGFloat iconSize;
 @property CGFloat activeLight;
@@ -14,7 +14,7 @@
 
 - (void)setupDockWindow;
 - (void)addApplicationIcon:(NSString *)appName withDockedStatus:(BOOL)isDocked;
-- (NSButton *)generateIcon:(NSString *)appName;
+- (DockIcon *)generateIcon:(NSString *)appName;
 - (NSRect)generateLocation:(NSString *)dockPosition;
 - (void)addDivider;
 - (void)iconClicked:(id)sender;
@@ -24,6 +24,7 @@
 - (void)applicationIsLaunching:(NSNotification *)notification;
 - (void)applicationDidFinishLaunching:(NSNotification *)notification;
 - (void)applicationTerminated:(NSNotification *)notification;
+- (void)activeApplicationChanged:(NSNotification *)notification;
 - (void)checkForNewActivatedIcons;
 
 

--- a/DockAppController.h
+++ b/DockAppController.h
@@ -20,6 +20,11 @@
 - (void)iconClicked:(id)sender;
 - (void)dockIcon:(NSString *)appName;
 - (void)undockIcon:(NSString *)appName;
+- (BOOL)isAppDocked:(NSString *)appName;
+- (void)applicationIsLaunching:(NSNotification *)notification;
+- (void)applicationDidFinishLaunching:(NSNotification *)notification;
+- (void)applicationTerminated:(NSNotification *)notification;
+- (void)checkForNewActivatedIcons;
 
 
 @end

--- a/DockAppController.h
+++ b/DockAppController.h
@@ -5,29 +5,40 @@
 @interface DockAppController : NSObject <NSApplicationDelegate>
 
 @property (strong) NSWindow *dockWindow;
-@property (strong) NSMutableDictionary *dockedIcons;
-@property (strong) NSMutableDictionary *undockedIcons;
+@property (strong) NSMutableArray *dockedIcons;
+@property (strong) NSMutableArray *undockedIcons;
 @property (strong) NSWorkspace *workspace;
 @property CGFloat iconSize;
 @property CGFloat activeLight;
 @property CGFloat padding;
 
+// Dock Window Management
 - (void)setupDockWindow;
-- (void)addApplicationIcon:(NSString *)appName withDockedStatus:(BOOL)isDocked;
+- (void)updateDockWindow;
+
+// Icon Management
+// - (void)addApplicationIcon:(NSString *)appName withDockedStatus:(BOOL)isDocked; // DEPRECATED
 - (DockIcon *)generateIcon:(NSString *)appName withDockedStatus:(BOOL)isDocked;
-- (NSRect)generateLocation:(NSString *)dockPosition forDockedStatus:(BOOL)isDocked;
+- (NSRect)generateLocation:(NSString *)dockPosition forDockedStatus:(BOOL)isDocked atIndex:(CGFloat)index;
 - (void)addDivider;
 - (void)iconClicked:(id)sender;
-- (void)dockIcon:(NSString *)appName;
-- (void)undockIcon:(NSString *)appName;
-- (BOOL)isAppDocked:(NSString *)appName;
+- (DockIcon *)addIcon:(NSString *)appName toDockedArray:(BOOL)isDocked;
+- (void)removeIcon:(NSString *)appName fromDockedArray:(BOOL)isDocked;
+
+// Workspace Events
 - (void)applicationIsLaunching:(NSNotification *)notification;
 - (void)applicationDidFinishLaunching:(NSNotification *)notification;
 - (void)applicationTerminated:(NSNotification *)notification;
 - (void)activeApplicationChanged:(NSNotification *)notification;
+
+// Movers & Helpers
+- (BOOL)isIconDocked:(NSString *)appName;
+// - (BOOL)isAppRunning:(NSString *)appName;
+- (NSUInteger)indexOfIcon:(NSString *)appName byDockedStatus:(BOOL)isDocked;
 - (void)checkForNewActivatedIcons;
 - (CGFloat)calculateDockWidth;
-- (void)updateDockWindow;
+- (void)updateIconPositions:(BOOL)isDocked;
+- (DockIcon *)getIconByName:(NSString *)appName withDockedStatus:(BOOL)isDocked;
 
 
 @end

--- a/DockAppController.h
+++ b/DockAppController.h
@@ -4,6 +4,7 @@
 
 @interface DockAppController : NSObject <NSApplicationDelegate>
 
+@property (strong) NSString *dockPosition;
 @property (strong) NSWindow *dockWindow;
 @property (strong) NSMutableArray *dockedIcons;
 @property (strong) NSMutableArray *undockedIcons;
@@ -37,8 +38,8 @@
 - (NSUInteger)indexOfIcon:(NSString *)appName byDockedStatus:(BOOL)isDocked;
 - (void)checkForNewActivatedIcons;
 - (CGFloat)calculateDockWidth;
-- (void)updateIconPositions:(BOOL)isDocked;
 - (DockIcon *)getIconByName:(NSString *)appName withDockedStatus:(BOOL)isDocked;
+- (void)updateIconPositions:(NSUInteger)startIndex fromDockedIcons:(BOOL)isDocked expandDock:(BOOL)isExpanding;
 
 
 @end

--- a/DockAppController.h
+++ b/DockAppController.h
@@ -26,6 +26,8 @@
 - (void)applicationTerminated:(NSNotification *)notification;
 - (void)activeApplicationChanged:(NSNotification *)notification;
 - (void)checkForNewActivatedIcons;
+- (CGFloat)calculateDockWidth;
+- (void)updateDockWindow;
 
 
 @end

--- a/DockAppController.h
+++ b/DockAppController.h
@@ -4,6 +4,7 @@
 
 @interface DockAppController : NSObject <NSApplicationDelegate>
 
+@property (strong) NSArray *defaultIcons;
 @property (strong) NSString *dockPosition;
 @property (strong) NSWindow *dockWindow;
 @property (strong) NSMutableArray *dockedIcons;
@@ -41,6 +42,10 @@
 - (DockIcon *)getIconByName:(NSString *)appName withDockedStatus:(BOOL)isDocked;
 - (void)updateIconPositions:(NSUInteger)startIndex fromDockedIcons:(BOOL)isDocked expandDock:(BOOL)isExpanding;
 
+// Defaults
+- (void)resetDockedIcons;
+- (void)saveDockedIconsToUserDefaults;
+- (void)loadDockedIconsFromUserDefaults;
 
 @end
 

--- a/DockAppController.m
+++ b/DockAppController.m
@@ -115,6 +115,7 @@
 }
 
 - (void)updateDockWindow {
+    NSLog(@"Updating dock window...");
     // Adjust the width
     CGFloat dockWidth = [self calculateDockWidth];
     NSSize currentContentSize = [self.dockWindow.contentView frame].size;
@@ -122,11 +123,13 @@
     [self.dockWindow setContentSize:newContentSize];
 
     // Center on screen
+    /*
     NSScreen *mainScreen = [NSScreen mainScreen];
     NSRect viewport = [mainScreen frame];
     CGFloat newX = (viewport.size.width / 2) - (dockWidth / 2);
     NSRect currentFrame = [self.dockWindow.contentView frame];
     NSRect newFrame = NSMakeRect(newX, currentFrame.origin.y, currentFrame.size.width, currentFrame.size.height);
+    */
 }
 
 - (void)addApplicationIcon:(NSString *)appName withDockedStatus:(BOOL)isDocked {
@@ -212,7 +215,7 @@
     }
 }
 
-- (void)applicationIsLaunching:(NSNotification *)notification {
+- (void)applicationDidFinishLaunching:(NSNotification *)notification {
     NSDictionary *userInfo = [notification userInfo];
     NSString *appName = userInfo[@"NSApplicationName"];
     if (appName) {
@@ -241,7 +244,7 @@
     [self checkForNewActivatedIcons];
 }
 
-- (void)applicationDidFinishLaunching:(NSNotification *)notification {
+- (void)applicationIsLaunching:(NSNotification *)notification {
     // TODO: STOP BOUNCE
     NSLog(@"Stop the bounce");
 }

--- a/DockAppController.m
+++ b/DockAppController.m
@@ -122,14 +122,13 @@
     NSSize newContentSize = NSMakeSize(dockWidth, currentContentSize.height); // width, height
     [self.dockWindow setContentSize:newContentSize];
 
-    // Center on screen
-    /*
+    // Center on screen  
     NSScreen *mainScreen = [NSScreen mainScreen];
     NSRect viewport = [mainScreen frame];
     CGFloat newX = (viewport.size.width / 2) - (dockWidth / 2);
     NSRect currentFrame = [self.dockWindow.contentView frame];
     NSRect newFrame = NSMakeRect(newX, currentFrame.origin.y, currentFrame.size.width, currentFrame.size.height);
-    */
+   
 }
 
 - (void)addApplicationIcon:(NSString *)appName withDockedStatus:(BOOL)isDocked {

--- a/DockAppController.m
+++ b/DockAppController.m
@@ -76,7 +76,7 @@
     // TODO: Fetch Docked Apps from Prefs
     
     // Add default applications icons to the dock window
-    [self addApplicationIcon:@"GWorkspace" withDockedStatus:YES];
+    [self addApplicationIcon:@"Workspace" withDockedStatus:YES];
     [self addApplicationIcon:@"Terminal" withDockedStatus:YES];
     [self addApplicationIcon:@"SystemPreferences" withDockedStatus:YES];
 
@@ -124,7 +124,7 @@
     NSRect viewport = [mainScreen frame];
     CGFloat newX = (viewport.size.width / 2) - (dockWidth / 2);
     NSRect currentFrame = [self.dockWindow.contentView frame];
-    NSRect newFrame = NSMakeRect(newX, currentFrame.origin.y, currentFrame.size.width, currentFrame.size.height);
+    NSRect newFrame = NSMakeRect(newX, self.padding, currentFrame.size.width, currentFrame.size.height);
     [self.dockWindow setFrame:newFrame display:YES];
    
 }

--- a/DockAppController.m
+++ b/DockAppController.m
@@ -6,7 +6,8 @@
 
 - (instancetype)init {
     self = [super init];
-    if (self) {
+    if (self)
+      {
         _defaultIcons = [NSArray arrayWithObjects:@"Workspace", @"Terminal", @"SystemPreferences", nil];
         _dockPosition = @"Bottom";
         _dockedIcons = [[NSMutableArray alloc] init];
@@ -20,30 +21,30 @@
         NSNotificationCenter *workspaceNotificationCenter = [self.workspace notificationCenter];
         // Subscribe to the NSWorkspaceWillLaunchApplicationNotification
         [workspaceNotificationCenter addObserver:self
-                                              selector:@selector(applicationIsLaunching:)
-                                              name:NSWorkspaceWillLaunchApplicationNotification 
-                                              object:nil];
+                                        selector:@selector(applicationIsLaunching:)
+                                            name:NSWorkspaceWillLaunchApplicationNotification 
+                                          object:nil];
 
         // Subscribe to the NSWorkspaceDidLaunchApplicationNotification
         [workspaceNotificationCenter addObserver:self
-                                              selector:@selector(applicationDidFinishLaunching:)
-                                              name:NSWorkspaceDidLaunchApplicationNotification 
-                                              object:nil];
+                                        selector:@selector(applicationDidFinishLaunching:)
+                                            name:NSWorkspaceDidLaunchApplicationNotification 
+                                          object:nil];
 
         // Subscribe to NSWorkspaceDidActivateApplicationNotification: Sent when an application is terminated.
         [workspaceNotificationCenter addObserver:self
-                                              selector:@selector(applicationTerminated:)
-                                              name:NSWorkspaceDidTerminateApplicationNotification
-                                              object:nil];
+                                        selector:@selector(applicationTerminated:)
+                                            name:NSWorkspaceDidTerminateApplicationNotification
+                                           object:nil];
 
         // Subscribe to NSApplicationDidBecomeActiveNotification: Sent when an application becomes active.
         [workspaceNotificationCenter addObserver:self
-                                              selector:@selector(activeApplicationChanged:)
-                                              name:NSApplicationDidBecomeActiveNotification // is NSWorkspaceDidActivateApplicationNotification on MacOS
-                                              object:nil];
+                                        selector:@selector(activeApplicationChanged:)
+                                            name:NSApplicationDidBecomeActiveNotification // is NSWorkspaceDidActivateApplicationNotification on MacOS
+                                           object:nil];
 
         [self setupDockWindow];
-    }
+      }
     return self;
 }
 
@@ -52,7 +53,8 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self]; 
 }
 
-- (void)resetDockedIcons {
+- (void) resetDockedIcons
+{
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSMutableArray *appNames = [NSMutableArray array];
 
@@ -65,7 +67,8 @@
     [defaults synchronize]; // Optional, to save changes immediately 
 }
 
-- (void)saveDockedIconsToUserDefaults:(BOOL)reset {
+- (void) saveDockedIconsToUserDefaults:(BOOL)reset
+{
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     if (reset){
       // Reset the local array
@@ -83,11 +86,13 @@
     }
 }
 
-- (void)loadDockedIconsFromUserDefaults {
+- (void) loadDockedIconsFromUserDefaults
+{
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSArray<NSString *> *retrievedDockedIcons = [defaults objectForKey:@"DockedIcons"];
 
-    if ([retrievedDockedIcons count] > 0) {
+    if ([retrievedDockedIcons count] > 0)
+      {
       NSLog(@"Defaults Exist");
       NSMutableArray *newArray = [[NSMutableArray alloc] init];
       _dockedIcons = newArray;
@@ -100,68 +105,72 @@
       _dockedIcons = newArray;
       [self updateDockWindow];
 
-    } else {
-      NSLog(@"Defaults not found. Generating defaults");
-      // If NSUserDefaults are missing, reset to defaults
-      [self resetDockedIcons];
-      [self updateDockWindow];
-    }
+      } else {
+        NSLog(@"Defaults not found. Generating defaults");
+        // If NSUserDefaults are missing, reset to defaults
+        [self resetDockedIcons];
+        [self updateDockWindow];
+      }
 }
 
-- (void)setupDockWindow {
-    // Create a dock window without a title bar or standard window buttons 
-    CGFloat dockWidth = [self calculateDockWidth];// (self.padding * 2 + totalIcons * self.iconSize);
-    // Get the main screen (primary display)
-    NSScreen *mainScreen = [NSScreen mainScreen];
-    NSRect viewport = [mainScreen frame];
-    CGFloat x = (viewport.size.width / 2) - (dockWidth / 2);
-    NSRect frame = NSMakeRect(x, 16, dockWidth, 8 + self.activeLight + self.iconSize);  // Set size and position of the dock (x, y, w, h)
-    self.dockWindow = [[NSWindow alloc] initWithContentRect:frame
-                                                  styleMask:NSWindowStyleMaskBorderless
-                                                    backing:NSBackingStoreBuffered
-                                                      defer:NO];
-    [self.dockWindow setTitle:@"Dock"];
-    [self.dockWindow setLevel:NSFloatingWindowLevel];
-    [self.dockWindow setOpaque:NO];
+- (void) setupDockWindow
+{
+  // Create a dock window without a title bar or standard window buttons 
+  CGFloat dockWidth = [self calculateDockWidth];// (self.padding * 2 + totalIcons * self.iconSize);
+  // Get the main screen (primary display)
+  NSScreen *mainScreen = [NSScreen mainScreen];
+  NSRect viewport = [mainScreen frame];
+  CGFloat x = (viewport.size.width / 2) - (dockWidth / 2);
+  NSRect frame = NSMakeRect(x, 16, dockWidth, 8 + self.activeLight + self.iconSize);  // Set size and position of the dock (x, y, w, h)
+  self.dockWindow = [[NSWindow alloc] initWithContentRect:frame
+                                                styleMask:NSWindowStyleMaskBorderless
+                                                  backing:NSBackingStoreBuffered
+                                                    defer:NO];
+  [self.dockWindow setTitle:@"Dock"];
+  [self.dockWindow setLevel:NSFloatingWindowLevel];
+  [self.dockWindow setOpaque:NO];
  
-    // Set the window's background color with transparency (alpha < 1.0)
-    NSColor *semiTransparentColor = [NSColor colorWithCalibratedWhite:0.1 alpha:0.75];
-    [self.dockWindow setBackgroundColor:semiTransparentColor];
-    
-    // Fetch Docked Apps from Prefs 
-    [self loadDockedIconsFromUserDefaults];
+  // Set the window's background color with transparency (alpha < 1.0)
+  NSColor *semiTransparentColor = [NSColor colorWithCalibratedWhite:0.1 alpha:0.75];
+  [self.dockWindow setBackgroundColor:semiTransparentColor];
+  
+  // Fetch Docked Apps from Prefs 
+  [self loadDockedIconsFromUserDefaults];
 
-    // TODO: Create Divider
+  // TODO: Create Divider
 
-    // Fetch Running Apps from Workspace
-    NSArray *runningApps = [self.workspace launchedApplications];
-    for (int i = 0; i < [runningApps count]; i++) {
-        NSString *runningAppName = [[runningApps objectAtIndex: i] objectForKey: @"NSApplicationName"];  
-        if ([self isIconDocked:runningAppName]) {
-          DockIcon *dockedIcon = [self getIconByName:runningAppName withDockedStatus:YES];          
-          [dockedIcon setActiveLightVisibility:YES]; 
-        } else if([runningAppName isEqualToString:@"Dock"]) {
-          // Don't show dock
-        } else {
-          [self addIcon:runningAppName toDockedArray:NO];
-        }
+  // Fetch Running Apps from Workspace
+  NSArray *runningApps = [self.workspace launchedApplications];
+  for (int i = 0; i < [runningApps count]; i++)
+    {
+      NSString *runningAppName = [[runningApps objectAtIndex: i] objectForKey: @"NSApplicationName"];  
+      if ([self isIconDocked:runningAppName]) {
+        DockIcon *dockedIcon = [self getIconByName:runningAppName withDockedStatus:YES];          
+        [dockedIcon setActiveLightVisibility:YES]; 
+      } else if([runningAppName isEqualToString:@"Dock"]) {
+        // Don't show dock
+      } else {
+        [self addIcon:runningAppName toDockedArray:NO];
+      }
     }
-    
-    // Set all the active lights for running apps
-    [self checkForNewActivatedIcons];
+  
+  // Set all the active lights for running apps
+  [self checkForNewActivatedIcons];
 
-    //Resize Dock Window
-    [self updateDockWindow];
-    
-    [self.dockWindow makeKeyAndOrderFront:nil];
+  //Resize Dock Window
+  [self updateDockWindow];
+  
+  [self.dockWindow makeKeyAndOrderFront:nil];
 }
 
-- (CGFloat)calculateDockWidth {
+- (CGFloat) calculateDockWidth
+{
     CGFloat dockWidth = (self.padding * 2 + ([_dockedIcons count] + [_undockedIcons count]) * self.iconSize);
     return dockWidth;
 }
 
-- (void)updateDockWindow {
+- (void) updateDockWindow
+{
     // Adjust the width
     CGFloat dockWidth = [self calculateDockWidth];
     NSSize currentContentSize = [self.dockWindow.contentView frame].size;
@@ -177,43 +186,51 @@
     [self.dockWindow setFrame:newFrame display:YES];
 }
 
-- (void)updateIconPositions:(NSUInteger)startIndex fromDockedIcons:(BOOL)isDocked expandDock:(BOOL)isExpanding{
+- (void) updateIconPositions:(NSUInteger)startIndex
+             fromDockedIcons:(BOOL)isDocked
+                  expandDock:(BOOL)isExpanding
+{
     // If isDocked, we need to move subset of dockedIcons and all of the undockedIcons so we create a global array.
     // Otherwise we move subset of undockedIcons only.
     NSMutableArray *targetArray = nil;
-    if(isDocked) {
-      targetArray = [_dockedIcons arrayByAddingObjectsFromArray:_undockedIcons];
-    } else {
-      targetArray = _undockedIcons;
-    }
-
-    for (int i = startIndex; i < [targetArray count]; i++) {
-      DockIcon *dockIcon = [targetArray objectAtIndex:i];
-      NSRect currentFrame = [dockIcon frame];
-
-      // Horizontal adjustments
-      if([_dockPosition isEqualToString:@"Bottom"]) {
-        CGFloat startX = currentFrame.origin.x;
-
-        if(isExpanding){
-          CGFloat expandedX = currentFrame.origin.x + _iconSize;          
-          NSRect expandedFrame = NSMakeRect(expandedX, currentFrame.origin.y , self.iconSize, self.iconSize);
-          [dockIcon setFrame:expandedFrame]; // Replace with tween
-        } else {
-          CGFloat contractedX = currentFrame.origin.x - _iconSize;
-          NSRect contractedFrame = NSMakeRect(contractedX, currentFrame.origin.y , self.iconSize, self.iconSize);
-          [dockIcon setFrame:contractedFrame]; // Replace with tween
-        } 
-
+    if(isDocked)
+      {
+        targetArray = [_dockedIcons arrayByAddingObjectsFromArray:_undockedIcons];
+      } else {
+        targetArray = _undockedIcons;
       }
-    }   
+
+    for (int i = startIndex; i < [targetArray count]; i++)
+      {
+        DockIcon *dockIcon = [targetArray objectAtIndex:i];
+        NSRect currentFrame = [dockIcon frame];
+  
+        // Horizontal adjustments
+        if([_dockPosition isEqualToString:@"Bottom"]) {
+          CGFloat startX = currentFrame.origin.x;
+  
+          if(isExpanding){
+            CGFloat expandedX = currentFrame.origin.x + _iconSize;          
+            NSRect expandedFrame = NSMakeRect(expandedX, currentFrame.origin.y , self.iconSize, self.iconSize);
+            [dockIcon setFrame:expandedFrame]; // Replace with tween
+          } else {
+            CGFloat contractedX = currentFrame.origin.x - _iconSize;
+            NSRect contractedFrame = NSMakeRect(contractedX, currentFrame.origin.y , self.iconSize, self.iconSize);
+            [dockIcon setFrame:contractedFrame]; // Replace with tween
+          } 
+  
+        }
+      }   
 }
 
-- (void)addDivider {
+- (void) addDivider
+{
   // TODO
 }
 
-- (DockIcon *)addIcon:(NSString *)appName toDockedArray:(BOOL)isDocked{
+- (DockIcon *) addIcon:(NSString *)appName
+         toDockedArray:(BOOL)isDocked
+{
     // TODO: Animation Logic
     NSMutableArray *iconsArray = isDocked ? _dockedIcons : _undockedIcons;
     DockIcon *dockIcon = [self generateIcon:appName withDockedStatus:isDocked];
@@ -226,33 +243,39 @@
     return dockIcon;
 }
 
-- (void)removeIcon:(NSString *)appName fromDockedArray:(BOOL)isDocked{
+- (void) removeIcon:(NSString *)appName
+    fromDockedArray:(BOOL)isDocked
+{
     // TODO: Animation Logic
     NSMutableArray *iconsArray = isDocked ? _dockedIcons : _undockedIcons;
     NSUInteger index = [self indexOfIcon:appName byDockedStatus:isDocked];
-    if(index != NSNotFound){ 
-      // NSLog(@"RemoveIcon Method: Removing %@", appName);
-      DockIcon *undockedIcon = [iconsArray objectAtIndex:index];
-      [undockedIcon selfDestruct];
-      [iconsArray removeObjectIdenticalTo:undockedIcon];
-      // Update Undocked Icons
-      [self updateIconPositions:index fromDockedIcons:isDocked expandDock:NO];
-      if (isDocked) {
-        [self saveDockedIconsToUserDefaults:NO];
+    if (index != NSNotFound)
+      { 
+        // NSLog(@"RemoveIcon Method: Removing %@", appName);
+        DockIcon *undockedIcon = [iconsArray objectAtIndex:index];
+        [undockedIcon selfDestruct];
+        [iconsArray removeObjectIdenticalTo:undockedIcon];
+        // Update Undocked Icons
+        [self updateIconPositions:index fromDockedIcons:isDocked expandDock:NO];
+        if (isDocked) {
+          [self saveDockedIconsToUserDefaults:NO];
+        }
+      } else {
+        NSLog(@"Error: Either not found or out of range. Could not remove %@", appName);
       }
-    } else {
-      NSLog(@"Error: Either not found or out of range. Could not remove %@", appName);
-    }
 }
 
-- (BOOL)isIconDocked:(NSString *)appName {
+- (BOOL) isIconDocked:(NSString *)appName
+{
     BOOL defaultValue = NO;
     // DockIcon *dockedApp = [self.dockedIcons objectForKey:appName];
     NSUInteger index = [self indexOfIcon:appName byDockedStatus: YES];
     return index != NSNotFound ? YES : defaultValue;
 }
 
-- (NSUInteger)indexOfIcon:(NSString *)appName byDockedStatus:(BOOL)isDocked{
+- (NSUInteger) indexOfIcon:(NSString *)appName
+            byDockedStatus:(BOOL)isDocked
+{
     NSMutableArray *iconsArray = isDocked ? _dockedIcons : _undockedIcons;
     NSUInteger index = [iconsArray indexOfObjectPassingTest:^BOOL(id obj, NSUInteger idx, BOOL *stop) {
         // 'obj' is the current object in the array 
@@ -264,7 +287,9 @@
     return index;
 }
 
-- (DockIcon *)getIconByName:(NSString *)appName withDockedStatus:(BOOL)isDocked { 
+- (DockIcon *) getIconByName:(NSString *)appName
+            withDockedStatus:(BOOL)isDocked
+{ 
     NSMutableArray *iconsArray = isDocked ? _dockedIcons : _undockedIcons;
     NSUInteger index = [self indexOfIcon:appName byDockedStatus: YES];
     
@@ -276,12 +301,14 @@
     }
 }
 
-- (void) checkForNewActivatedIcons {
+- (void) checkForNewActivatedIcons
+{
   // Update Dock Icons Arrays
   NSLog(@"checkForNewActivatedIcons Method...");
   // Get the list of running applications
   NSArray *runningApps = [self.workspace launchedApplications];
-  for (int i = 0; i < [runningApps count]; i++) {
+  for (int i = 0; i < [runningApps count]; i++)
+    {
       NSString *runningAppName = [[runningApps objectAtIndex: i] objectForKey: @"NSApplicationName"];
       if ([runningAppName isEqualToString:@"Dock"]) {
         NSLog(@"Ignoring Dock App");
@@ -313,24 +340,30 @@
           }
         }
       }
-  }
-}
-
-- (NSRect)generateLocation:(NSString *)dockPosition forDockedStatus:(BOOL)isDocked atIndex:(CGFloat)index{
-    if([dockPosition isEqualToString:@"Left"]) {
-      NSRect leftLocation = NSMakeRect(self.activeLight, [self.dockedIcons count] * self.iconSize + (self.padding), self.iconSize, self.iconSize);
-      return leftLocation;
-    } else if([dockPosition isEqualToString:@"Right"]) {
-      NSRect rightLocation = NSMakeRect(self.activeLight, [self.dockedIcons count] * self.iconSize + (self.padding), self.iconSize, self.iconSize);
-      return rightLocation;
-    } else {
-      // If unset we default to "Bottom"      
-      NSRect bottomLocation = NSMakeRect(index * self.iconSize + (self.padding), self.activeLight, self.iconSize, self.iconSize);     
-      return bottomLocation;
     }
 }
 
-- (DockIcon *)generateIcon:(NSString *)appName withDockedStatus:(BOOL)isDocked {
+- (NSRect) generateLocation:(NSString *)dockPosition
+            forDockedStatus:(BOOL)isDocked
+                    atIndex:(CGFloat) index
+{
+    if([dockPosition isEqualToString:@"Left"])
+      {
+        NSRect leftLocation = NSMakeRect(self.activeLight, [self.dockedIcons count] * self.iconSize + (self.padding), self.iconSize, self.iconSize);
+        return leftLocation;
+      } else if([dockPosition isEqualToString:@"Right"]) {
+        NSRect rightLocation = NSMakeRect(self.activeLight, [self.dockedIcons count] * self.iconSize + (self.padding), self.iconSize, self.iconSize);
+        return rightLocation;
+      } else {
+        // If unset we default to "Bottom"      
+        NSRect bottomLocation = NSMakeRect(index * self.iconSize + (self.padding), self.activeLight, self.iconSize, self.iconSize);     
+        return bottomLocation;
+      }
+}
+
+- (DockIcon *) generateIcon:(NSString *)appName
+           withDockedStatus:(BOOL)isDocked
+{
     CGFloat iconCount = isDocked ? [self.dockedIcons count] : [self.dockedIcons count] + [self.undockedIcons count];
     NSRect location = [self generateLocation:_dockPosition forDockedStatus:isDocked atIndex:iconCount];  
     DockIcon *appButton = [[DockIcon alloc] initWithFrame:location];
@@ -347,77 +380,88 @@
 
 // Events
 
-- (void)iconClicked:(DockIcon *)sender{
+- (void) iconClicked:(DockIcon *)sender
+{
     DockIcon *dockIcon = (DockIcon *)sender;
     NSString *appName = [dockIcon getAppName];
     
-    if ([appName isEqualToString:@"Trash"]) {
-      // TODO Pull up Trash UI
-    } else if ([appName isEqualToString:@"Dock"]) {
-      // IGNORE this app if it comes up in the list
-    } else {
-      [self.workspace launchApplication:appName];
-    }
+    if ([appName isEqualToString:@"Trash"])
+      {
+        // TODO Pull up Trash UI
+      } else if ([appName isEqualToString:@"Dock"]) {
+        // IGNORE this app if it comes up in the list
+      } else {
+        [self.workspace launchApplication:appName];
+      }
 }
 
-- (void)applicationDidFinishLaunching:(NSNotification *)notification {
+- (void) applicationDidFinishLaunching:(NSNotification *)notification
+{
     NSDictionary *userInfo = [notification userInfo];
     NSString *appName = userInfo[@"NSApplicationName"];
-    if (appName) {
-      if ([appName isEqualToString:@"Dock"]) {
-          return;
-      }
-
-      //TODO  Manage the undocked list here
-      BOOL isDocked = [self isIconDocked:appName];
-      if (isDocked) {
-        DockIcon *dockedIcon = [self getIconByName:appName withDockedStatus:YES];
+    if (appName)
+      {
+        if ([appName isEqualToString:@"Dock"])
+        {
+            return;
+        }
+  
+        //TODO  Manage the undocked list here
+        BOOL isDocked = [self isIconDocked:appName];
+        if (isDocked) {
+          DockIcon *dockedIcon = [self getIconByName:appName withDockedStatus:YES];
+        } else {
+          // Add to undocked list
+          DockIcon *undockedIcon = [self addIcon:appName toDockedArray:NO];        
+        }
+        [self checkForNewActivatedIcons];
+        [self updateDockWindow];
       } else {
-        // Add to undocked list
-        DockIcon *undockedIcon = [self addIcon:appName toDockedArray:NO];        
+        NSLog(@"Application launched, but could not retrieve name.");
       }
-      [self checkForNewActivatedIcons];
-      [self updateDockWindow];
-    } else {
-      NSLog(@"Application launched, but could not retrieve name.");
-    }
 
     // TODO: STOP BOUNCE
     NSLog(@"Stop the bounce");
 }
 
-- (void)applicationIsLaunching:(NSNotification *)notification {
+- (void) applicationIsLaunching:(NSNotification *)notification
+{
     // TODO: ICON BOUNCE
     NSLog(@"Get ready to bounce"); 
 }
 
-- (void)applicationTerminated:(NSNotification *)notification {
+- (void) applicationTerminated:(NSNotification *)notification
+{
     NSDictionary *userInfo = [notification userInfo];
     NSString *appName = userInfo[@"NSApplicationName"];
-    if (appName) {
-      // Manage the undocked list here
-      BOOL isDocked = [self isIconDocked:appName];
-      if (isDocked) {
-        DockIcon *dockedIcon = [self getIconByName:appName withDockedStatus:YES];
-        [dockedIcon setActiveLightVisibility:NO];
-        [self checkForNewActivatedIcons];
+    if (appName)
+      {
+        // Manage the undocked list here
+        BOOL isDocked = [self isIconDocked:appName];
+        if (isDocked)
+        {
+          DockIcon *dockedIcon = [self getIconByName:appName withDockedStatus:YES];
+          [dockedIcon setActiveLightVisibility:NO];
+          [self checkForNewActivatedIcons];
+        } else {
+          [self removeIcon:appName fromDockedArray:NO];        
+        }
+        [self updateDockWindow];
       } else {
-        [self removeIcon:appName fromDockedArray:NO];        
+        NSLog(@"Application terminated, but could not retrieve name.");
       }
-      [self updateDockWindow];
-    } else {
-      NSLog(@"Application terminated, but could not retrieve name.");
-    }
 }
 
-- (void)activeApplicationChanged:(NSNotification *)notification {
+- (void) activeApplicationChanged:(NSNotification *)notification
+{
     NSDictionary *userInfo = [notification userInfo];
     NSString *appName = userInfo[@"NSApplicationName"];
-    if (appName) {
-      NSLog(@"%@ is active", appName);
-    } else {
-      NSLog(@"Active application changed, but could not retrieve name.");
-    }
+    if (appName)
+      {
+        NSLog(@"%@ is active", appName);
+      } else {
+        NSLog(@"Active application changed, but could not retrieve name.");
+      }
 }
 
 @end

--- a/DockAppController.m
+++ b/DockAppController.m
@@ -162,7 +162,6 @@
 }
 
 - (void)updateDockWindow {
-    // NSLog(@"Updating dock window...");
     // Adjust the width
     CGFloat dockWidth = [self calculateDockWidth];
     NSSize currentContentSize = [self.dockWindow.contentView frame].size;
@@ -210,16 +209,17 @@
     }   
 }
 
-- (void)addDivider {}
+- (void)addDivider {
+  // TODO
+}
 
 - (DockIcon *)addIcon:(NSString *)appName toDockedArray:(BOOL)isDocked{
-    // Adds icon to the array. Function will also contain animation logic
     // TODO: Animation Logic
     NSMutableArray *iconsArray = isDocked ? _dockedIcons : _undockedIcons;
     DockIcon *dockIcon = [self generateIcon:appName withDockedStatus:isDocked];
     [iconsArray addObject:dockIcon];
     [[self.dockWindow contentView] addSubview:dockIcon];
-    // NSLog(@"Undocked Count: %lu",(unsigned long)[_undockedIcons count]);
+
     if (isDocked) {
       [self saveDockedIconsToUserDefaults:NO];
     }
@@ -227,7 +227,6 @@
 }
 
 - (void)removeIcon:(NSString *)appName fromDockedArray:(BOOL)isDocked{
-    // Adds icon to the array. Function will also contain animation logic
     // TODO: Animation Logic
     NSMutableArray *iconsArray = isDocked ? _dockedIcons : _undockedIcons;
     NSUInteger index = [self indexOfIcon:appName byDockedStatus:isDocked];
@@ -243,7 +242,6 @@
       }
     } else {
       NSLog(@"Error: Either not found or out of range. Could not remove %@", appName);
-      // NSLog(@"Index:%f , Length: %f",index,[iconsArray count]);
     }
 }
 
@@ -260,7 +258,6 @@
         // 'obj' is the current object in the array 
         DockIcon *dockIcon = (DockIcon *)obj;
         
-        // Return YES if the DockIcon name matches the appName param
         return [[dockIcon getAppName] isEqualToString:appName];
     }];
 
@@ -298,10 +295,9 @@
         NSLog(@"dockedIcon name is %@", [dockedIcon getAppName]);
         [dockedIcon setActiveLightVisibility:YES];
       } else {
-        // DockIcon *undockedIcon = [self addIcon:runningAppName toDockedArray:NO];
         NSUInteger found = [self indexOfIcon:runningAppName byDockedStatus:NO];
         NSLog(@"Finding undockedIcon for %@", runningAppName);
-        //NSLog(@"undockedIcon name is %@", [undockedIcon getAppName]);
+
         if (found != NSNotFound){
           NSLog(@"Icon found for app %@", runningAppName);
           // DockIcon *undockedIcon = [self getIconByName:runningAppName withDockedStatus:NO];
@@ -359,8 +355,6 @@
       // TODO Pull up Trash UI
     } else if ([appName isEqualToString:@"Dock"]) {
       // IGNORE this app if it comes up in the list
-      // DockIcon *undockedIcon = [_undockedIcons objectForKey:appName];
-      //[_undockedIcons removeObjectForKey:appName];
     } else {
       [self.workspace launchApplication:appName];
     }
@@ -420,9 +414,9 @@
     NSDictionary *userInfo = [notification userInfo];
     NSString *appName = userInfo[@"NSApplicationName"];
     if (appName) {
-      // NSLog(@"%@ is active", appName);
+      NSLog(@"%@ is active", appName);
     } else {
-      // NSLog(@"Active application changed, but could not retrieve name.");
+      NSLog(@"Active application changed, but could not retrieve name.");
     }
 }
 

--- a/DockAppController.m
+++ b/DockAppController.m
@@ -145,17 +145,14 @@
 }
 
 - (void)iconClicked:(DockIcon *)sender{
-    //NSButton *clickedButton = (NSButton *)sender;
-    //NSString *appName = [clickedButton title];
     DockIcon *dockIcon = (DockIcon *)sender;
     NSString *appName = [dockIcon getAppName];
-    NSLog(@"CLICKED!");
     
     if ([appName isEqualToString:@"Trash"]) {
-      // NSLog(@"Launching application: %@", appName);
+      // TODO Pull up Trash UI
     } else if ([appName isEqualToString:@"Dock"]) {
+      // IGNORE this app if it comes up in the list
     } else {
-      NSLog(@"CLICKED!");
       [self.workspace launchApplication:appName];
     }
 }
@@ -179,15 +176,14 @@
 
 - (void) checkForNewActivatedIcons {
   // Update Dock Icons Arrays
-  NSLog(@"Updating Dock Icon States...");
+  NSLog(@"Looking up launchedApplications...");
   // Get the list of running applications
-  NSArray *runningApps = [self.workspace runningApplications];
-  // FIXME: Not sure how to parse this. Each Array item contains a dictionary but I don't know how to deal with those yet 
-  for (NSDictionary *appDictionary in runningApps) {
-      NSString *runningAppName = [appDictionary objectForKey:@"NSApplicationName"];
-      NSLog(@"%@", runningAppName);
+  NSArray *runningApps = [self.workspace launchedApplications];
+  for (int i = 0; i < [runningApps count]; i++) {
+      NSString *runningAppName = [[runningApps objectAtIndex: i] objectForKey: @"NSApplicationName"];
       DockIcon *dockedIcon = [_dockedIcons objectForKey:runningAppName];
       [dockedIcon setActiveLightVisibility:YES];
+      NSLog(@"Running App: %@", runningAppName);
   }
 }
 
@@ -199,6 +195,8 @@
 
       DockIcon *dockedIcon = [_dockedIcons objectForKey:appName];
       [dockedIcon setActiveLightVisibility:NO];
+      
+      //TODO  Manage the undocked list here
       //[self checkForNewActivatedIcons];
 
     } else {
@@ -213,6 +211,8 @@
       NSLog(@"%@ is active", appName);
       DockIcon *dockedIcon = [_dockedIcons objectForKey:appName];
       [dockedIcon setActiveLightVisibility:YES];
+
+      //TODO  Manage the undocked list here
       //[self checkForNewActivatedIcons];
     } else {
       NSLog(@"Active application changed, but could not retrieve name.");
@@ -220,4 +220,3 @@
 }
 
 @end
-

--- a/DockIcon.h
+++ b/DockIcon.h
@@ -1,15 +1,28 @@
 #import <Foundation/Foundation.h>
 #import <AppKit/AppKit.h>
+#import "ActiveLight.h"
 
-@interface DockIcon : NSObject 
+@interface DockIcon : NSButton 
 
 @property (strong) NSImage *iconImage;
-@property  BOOL *showLabel;
+@property (strong) NSString *appName;
+@property  BOOL showLabel;
 @property (strong) NSWorkspace *workspace;
+@property (strong) ActiveLight *activeLight;
+
 
 - (void)setupDockIcon;
 
-- (void)setLabelVisibility:(BOOL *)isVisible;
+- (void)setLabelVisibility:(BOOL)isVisible;
 
+// - (NSImage *)getIconImage;
+
+// - (void)setIconImage:(NSImage *)iconImage;
+
+- (NSString *)getAppName;
+
+- (void)setAppName:(NSString *)name;
+
+- (void)setActiveLightVisibility:(BOOL)isVisible;
 @end
 

--- a/DockIcon.h
+++ b/DockIcon.h
@@ -24,5 +24,8 @@
 - (void)setAppName:(NSString *)name;
 
 - (void)setActiveLightVisibility:(BOOL)isVisible;
+
+- (void)selfDestruct;
+
 @end
 

--- a/DockIcon.m
+++ b/DockIcon.m
@@ -41,6 +41,7 @@
     
     // Add ActiveLight as a subview to DockIcon
     [self addSubview:_activeLight];
+
 };
 
 - (void)setLabelVisibility:(BOOL) isVisible {
@@ -59,7 +60,7 @@
 
 - (void)setAppName:(NSString *)name {
     _appName = name;
-    [super setToolTip:_appName];
+    [super setToolTip:_appName]; 
 }
 
 - (void)selfDestruct {

--- a/DockIcon.m
+++ b/DockIcon.m
@@ -1,29 +1,65 @@
 #import <Foundation/Foundation.h>
 #import <AppKit/AppKit.h>
 #import "DockIcon.h"
+#import "ActiveLight.h"
 
 @implementation DockIcon
 
-- (instancetype)initWithImage:(NSImage *)iconImage {
-    self = [super init];
+- (instancetype)initWithFrame:(NSRect)frameRect{
+    self = [super initWithFrame:frameRect];
+
     if (self) {
-        _iconImage = iconImage;
+        // _iconImage = nil;
+        _appName = @"Unknown";
         _showLabel = YES; // Change this to NO 
-        [self setupDockIcon];
+        _activeLight = nil; // Change this to NO 
+
+      [self setupDockIcon];
     }
     return self;
 }
 
-// @property (strong) NSImage *iconImage;
-// @property (strong) BOOL *showLabel;
-// @property (strong) NSWorkspace *workspace;
-
 - (void)setupDockIcon {
-  // Do Stuff
+    // Do Stuff
+    [super setToolTip:_appName];
+
+    // Calculate the frame for the ActiveLight view
+    CGFloat lightDiameter = 4.0;
+    NSRect bounds = [self bounds];
+    // bounds.size.height += 4;
+
+    // Calculate the x and y position to center the ActiveLight horizontally and place it at the bottom
+    CGFloat xPosition = NSMidX(bounds) - (lightDiameter / 2.0);
+    CGFloat yPosition = bounds.size.height - 4;  // Set a small margin from the bottom edge
+
+    NSRect activeLightFrame = NSMakeRect(xPosition, yPosition, lightDiameter, lightDiameter);
+    
+    // Instantiate the ActiveLight view
+    _activeLight = [[ActiveLight alloc] initWithFrame:activeLightFrame];
+    [_activeLight setVisibility:NO];
+
+    
+    // Add ActiveLight as a subview to DockIcon
+    [self addSubview:_activeLight];
 };
 
-- (void)setLabelVisibility:(BOOL *)isVisible {
+- (void)setLabelVisibility:(BOOL) isVisible {
   self.showLabel = isVisible;
+}
+
+- (void)setActiveLightVisibility:(BOOL)isVisible {
+    // Implement visibility toggle in ActiveLight Class
+    // Toggle visibility of ActiveLight
+    [self.activeLight setVisibility:isVisible];
+}
+
+- (NSString *)getAppName {
+  return _appName;
+}
+
+- (void)setAppName:(NSString *)name {
+    _appName = name;
+    [super setToolTip:_appName];
 }
 
 @end

--- a/DockIcon.m
+++ b/DockIcon.m
@@ -62,5 +62,9 @@
     [super setToolTip:_appName];
 }
 
+- (void)selfDestruct {
+    [self removeFromSuperview];
+}
+
 @end
 

--- a/DockIcon.m
+++ b/DockIcon.m
@@ -5,21 +5,24 @@
 
 @implementation DockIcon
 
-- (instancetype)initWithFrame:(NSRect)frameRect{
+- (instancetype) initWithFrame:(NSRect)frameRect
+{
     self = [super initWithFrame:frameRect];
 
-    if (self) {
-        // _iconImage = nil;
-        _appName = @"Unknown";
-        _showLabel = YES; // Change this to NO 
-        _activeLight = nil; // Change this to NO 
-
-      [self setupDockIcon];
-    }
+    if (self)
+      {
+          // _iconImage = nil;
+          _appName = @"Unknown";
+          _showLabel = YES; // Change this to NO 
+          _activeLight = nil; // Change this to NO 
+  
+        [self setupDockIcon];
+      }
     return self;
 }
 
-- (void)setupDockIcon {
+- (void) setupDockIcon
+{
     // Do Stuff
     [super setToolTip:_appName];
 
@@ -41,29 +44,33 @@
     
     // Add ActiveLight as a subview to DockIcon
     [self addSubview:_activeLight];
-
 };
 
-- (void)setLabelVisibility:(BOOL) isVisible {
+- (void) setLabelVisibility:(BOOL) isVisible
+{
   self.showLabel = isVisible;
 }
 
-- (void)setActiveLightVisibility:(BOOL)isVisible {
+- (void) setActiveLightVisibility:(BOOL)isVisible
+{
     // Implement visibility toggle in ActiveLight Class
     // Toggle visibility of ActiveLight
     [self.activeLight setVisibility:isVisible];
 }
 
-- (NSString *)getAppName {
+- (NSString *) getAppName
+{
   return _appName;
 }
 
-- (void)setAppName:(NSString *)name {
+- (void) setAppName:(NSString *)name
+{
     _appName = name;
     [super setToolTip:_appName]; 
 }
 
-- (void)selfDestruct {
+- (void) selfDestruct
+{
     [self removeFromSuperview];
 }
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,8 +1,11 @@
 include $(GNUSTEP_MAKEFILES)/common.make
 
 APP_NAME = Dock  # Name of the application
-Dock_OBJC_FILES = main.m DockAppController.m  # List of Objective-C source files
+Dock_OBJC_FILES = main.m DockAppController.m DockIcon.m ActiveLight.m # List of Objective-C source files
 Dock_RESOURCE_FILES = Resources/Info-gnustep.plist  # Resource files (plist, images, etc.)
+
+# Compiler flags to enable ARC
+ADDITIONAL_OBJCFLAGS = -fobjc-arc
 
 include $(GNUSTEP_MAKEFILES)/application.make
 

--- a/main.m
+++ b/main.m
@@ -2,7 +2,8 @@
 #import <AppKit/AppKit.h>
 #import "DockAppController.h"
 
-int main(int argc, const char *argv[]) {
+int main(int argc, const char *argv[])
+{
     @autoreleasepool {
         [NSApplication sharedApplication];
         DockAppController *controller = [[DockAppController alloc] init];


### PR DESCRIPTION
### Required features

1. Docked Icons and Active Undocked Icon areas
2. Store Docked Icons in Preferences somewhere
3. Working activity light under active Icons

## Docked Icons and Active Undocked Icon areas
Saved docked icons  are persistent and have their activity light get toggled as they are launched and terminated

## Store Docked Icons in Preferences somewhere
They are stored under Dock > DockedIcons which is an array of App Names as strings. You can verify this via CLI `defaults read Dock`

## Working activity light under active Icons
This is self explanatory. If you destroy an undocked (running but not saved to defaults) the icon disappears. Otherwise for docked icons the activity light gets toggled


The classes have been refactored to anticipate animation methods. Code style is non existent as my vim is set up for TypeScript and not Objective C. Would appreciate some pointers on this @gcasa 